### PR TITLE
Improve guide tab layout

### DIFF
--- a/4-weeks.html
+++ b/4-weeks.html
@@ -813,6 +813,30 @@ WFIUjBjRG92TDNkM2R5NTNNeTV2Y21jdk1qQXdNQzl6ZG1jaUlIZHBaSFJvUFNKeU5UWWlJR2hsYVdkb
                 font-size: 1.5em;
             }
         }
+
+        /* Guide tab readability tweaks */
+        #guideTab {
+            max-width: 750px;
+            margin: 0 auto;
+            line-height: 1.8;
+        }
+
+        #guideTab p {
+            margin-bottom: 16px;
+        }
+
+        #guideTab ul, #guideTab ol {
+            margin-bottom: 20px;
+            padding-left: 28px;
+        }
+
+        #guideTab li {
+            margin-bottom: 10px;
+        }
+
+        #guideTab .intro {
+            font-size: 1.1em;
+        }
     </style>
 </head>
 <body>
@@ -828,7 +852,7 @@ WFIUjBjRG92TDNkM2R5NTNNeTV2Y21jdk1qQXdNQzl6ZG1jaUlIZHBaSFJvUFNKeU5UWWlJR2hsYVdkb
         <div class="content-area">
             <div id="guideTab" class="tab-content section">
                 <h2>Program Guide</h2>
-                <p>Welcome to your personalized strength and conditioning plan tracker! This guide will help you understand how to use the app and follow the program effectively.</p>
+                <p class="intro">Welcome! This short guide explains how to use the tracker and follow your program effectively.</p>
 
                 <h4>Core Principles:</h4>
                 <ul>


### PR DESCRIPTION
## Summary
- tweak Program Guide intro text for brevity
- add CSS rules for the guide tab to increase spacing and limit width

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6855835034b08330b24a1b1cca805836